### PR TITLE
[75] Run unit tests when creating PR

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,11 +1,11 @@
-name: Build and Test on PR
+name: Run Unit Tests on PR
 
 on:
   pull_request:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,5 +22,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build and Test Debug
-        run: ./gradlew assembleDebug testDebug
+      - name: Run Unit Tests
+        run: ./gradlew testDebug


### PR DESCRIPTION
Closes #75. Replaced the build step with unit tests in the PR workflow.